### PR TITLE
My tests branch

### DIFF
--- a/tests/google.spec.js
+++ b/tests/google.spec.js
@@ -1,15 +1,14 @@
-test('Search for Playwright', async ({ page }) => {
+const { test, expect } = require('@playwright/test');
+
+test('Simple Google search with screenshot', async ({ page }) => {
   await page.goto('https://www.google.com');
 
-  // Dismiss cookie consent if present
-  const consentButton = page.locator('button', { hasText: /I agree|Accept all/i });
-  if (await consentButton.count() > 0) {
-    await consentButton.click();
-  }
+  // Take screenshot of the homepage
+  await page.screenshot({ path: 'screenshot.png' });
 
-  await page.waitForSelector('input[name="q"]', { state: 'visible', timeout: 10000 });
   await page.fill('input[name="q"]', 'Playwright');
   await page.keyboard.press('Enter');
+
   await page.waitForSelector('#search');
   const firstResult = await page.locator('#search .g').first().innerText();
   expect(firstResult.toLowerCase()).toContain('playwright');

--- a/tests/google.spec.js
+++ b/tests/google.spec.js
@@ -1,0 +1,16 @@
+test('Search for Playwright', async ({ page }) => {
+  await page.goto('https://www.google.com');
+
+  // Dismiss cookie consent if present
+  const consentButton = page.locator('button', { hasText: /I agree|Accept all/i });
+  if (await consentButton.count() > 0) {
+    await consentButton.click();
+  }
+
+  await page.waitForSelector('input[name="q"]', { state: 'visible', timeout: 10000 });
+  await page.fill('input[name="q"]', 'Playwright');
+  await page.keyboard.press('Enter');
+  await page.waitForSelector('#search');
+  const firstResult = await page.locator('#search .g').first().innerText();
+  expect(firstResult.toLowerCase()).toContain('playwright');
+});


### PR DESCRIPTION
### Summary

Add a simple Playwright test that performs a Google search and takes a screenshot.

### Details

- Opens https://www.google.com
- Takes a screenshot of the homepage (`screenshot.png`)
- Searches for the term "Playwright"
- Waits for search results to load
- Verifies that the first search result contains the word "playwright"

### How to test

- Run locally with `npx playwright test simple-google.spec.js`
- The test will create a screenshot file in the root folder
- Tests also run automatically in the GitHub Actions workflow on push and PR

### Notes

- This is a basic UI test to verify Playwright setup and simple navigation
- No cookie consent handling included; may fail if Google shows consent dialog
- Can be expanded later with more tests and improved error handling